### PR TITLE
Switch to TensorFlow Viterbi CRF decode.

### DIFF
--- a/model/ner_model.py
+++ b/model/ner_model.py
@@ -241,17 +241,23 @@ class NERModel(BaseModel):
         fd, sequence_lengths = self.get_feed_dict(words, dropout=1.0)
 
         if self.config.use_crf:
+            # In Python
             # get tag scores and transition params of CRF
-            viterbi_sequences = []
-            logits, trans_params = self.sess.run(
-                    [self.logits, self.trans_params], feed_dict=fd)
+            #viterbi_sequences = []
+            #logits, trans_params = self.sess.run(
+            #        [self.logits, self.trans_params], feed_dict=fd)
+            #
+            # iterate over the sentences because no batching in viterbi_decode
+            #for logit, sequence_length in zip(logits, sequence_lengths):
+            #    logit = logit[:sequence_length] # keep only the valid steps
+            #    viterbi_seq, viterbi_score = tf.contrib.crf.viterbi_decode(
+            #            logit, trans_params)
+            #    viterbi_sequences += [viterbi_seq]
 
-            # iterate over the sentences because no batching in vitervi_decode
-            for logit, sequence_length in zip(logits, sequence_lengths):
-                logit = logit[:sequence_length] # keep only the valid steps
-                viterbi_seq, viterbi_score = tf.contrib.crf.viterbi_decode(
-                        logit, trans_params)
-                viterbi_sequences += [viterbi_seq]
+            # In Tensorflow
+            viterbi_sequence, viterbi_score = tf.contrib.crf.crf_decode(
+                self.logits, self.trans_params, tf.constant(sequence_lengths))
+            viterbi_sequences = self.sess.run(viterbi_sequence, feed_dict=fd)
 
             return viterbi_sequences, sequence_lengths
 


### PR DESCRIPTION
Now there is a TensorFlow implementation of CRF decoding available (https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/crf).

I hope I used it correctly, but it does not seem to speed anything up substantially.